### PR TITLE
Reverse order checking elgg version

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -1806,11 +1806,11 @@ function elgg_solr_get_cores() {
 
 
 function elgg_solr_is_elgg18() {
-	if (is_callable('elgg_get_version')) {
-		return false; // this is newer than 1.8
-	}
-	
-	$is_elgg18 = (strpos(get_version(true), '1.8') === 0);
-	
-	return $is_elgg18;
+        $is_elgg18 = (strpos(get_version(true), '1.8') === 0);
+
+        return $is_elgg18;
+
+        if (is_callable('elgg_get_version')) {
+                return false; // this is newer than 1.8
+        }
 }


### PR DESCRIPTION
This way, it will not clash with other plugins, that define the function elgg_get_version() see our discussion on https://community.elgg.org/plugins/1635100/releases/1.8.1