### PR TITLE
Change how require_once is adding libraries

### DIFF
--- a/start.php
+++ b/start.php
@@ -2,9 +2,9 @@
 
 const ELGG_SOLR_UPGRADE_VERSION = 20141205;
 
-require_once 'lib/functions.php';
-require_once 'lib/hooks.php';
-require_once 'lib/events.php';
+require_once(dirname(__FILE__) . "/lib/functions.php");
+require_once(dirname(__FILE__) . "/lib/hooks.php");
+require_once(dirname(__FILE__) . "/lib/events.php");
 
 elgg_register_event_handler('init', 'system', 'elgg_solr_init');
 


### PR DESCRIPTION
There is a conflict with event manager and SOLR. I raised an issue and Jeroen Dalsem suggested this change. There is a conflict in how Elgg handles require_once with files with the exact name. I tested this and that solves the conflict. Other plugins also use this structure and would conflict with SOLR too