### PR TITLE
Force access id list to be OR instead of AND

### DIFF
--- a/languages/en.php
+++ b/languages/en.php
@@ -66,6 +66,7 @@ return [
 	'elgg_solr:time:year' => "Year(s)",
 	'elgg_solr:settings:query:time_boost:by' => "with a boost of",
 	'elgg_solr:settings:addortoaccess' => "Add 'OR' to access id list:",
+	'elgg_solr:settings:addortoaccess:help' => "This will add the 'OR' to the access_id list. This is useful when you've long access_id lists. See <a href=\"https://github.com/arckinteractive/elgg_solr/pull/29\">issue #29</a> for more details about this issue.",
 	'elgg_solr:settings:query:time_boost:help' => "Boost the relevancy of recent content.  The higher the boost value the more relevant it will become.  Default: 1.5",
 	'elgg_solr:settings:highlight:prefix' => "Highlight Prefix",
 	'elgg_solr:settings:highlight:prefix:help' => "HTML to insert in front of strings found to match the query.  Eg. &lt;strong&gt;",

--- a/languages/en.php
+++ b/languages/en.php
@@ -65,6 +65,7 @@ return [
 	'elgg_solr:time:month' => "Month(s)",
 	'elgg_solr:time:year' => "Year(s)",
 	'elgg_solr:settings:query:time_boost:by' => "with a boost of",
+	'elgg_solr:settings:addortoaccess' => "Add 'OR' to access id list:",
 	'elgg_solr:settings:query:time_boost:help' => "Boost the relevancy of recent content.  The higher the boost value the more relevant it will become.  Default: 1.5",
 	'elgg_solr:settings:highlight:prefix' => "Highlight Prefix",
 	'elgg_solr:settings:highlight:prefix:help' => "HTML to insert in front of strings found to match the query.  Eg. &lt;strong&gt;",

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -596,7 +596,13 @@ function elgg_solr_get_access_query() {
 
 	// access filter query
 	if ($access) {
-		$access_list = implode(' ', $access);
+		$access_list_glue = elgg_get_plugin_setting("addortoaccess_glue");
+		if ($access_list_glue == "yes") {
+			$access_list_glue = " OR ";
+		} else {
+			$access_list_glue = " ";
+		}
+		$access_list = implode($access_list_glue, $access);
 	}
 
 	if (elgg_is_logged_in()) {

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -596,11 +596,11 @@ function elgg_solr_get_access_query() {
 
 	// access filter query
 	if ($access) {
-		$access_list_glue = elgg_get_plugin_setting("addortoaccess_glue");
-		if ($access_list_glue == "yes") {
-			$access_list_glue = " OR ";
+		$access_list_glue = elgg_get_plugin_setting('addortoaccess_glue', 'elgg_solr');
+		if ($access_list_glue == 'yes') {
+			$access_list_glue = ' OR ';
 		} else {
-			$access_list_glue = " ";
+			$access_list_glue = ' ';
 		}
 		$access_list = implode($access_list_glue, $access);
 	}

--- a/views/default/plugins/elgg_solr/settings.php
+++ b/views/default/plugins/elgg_solr/settings.php
@@ -159,8 +159,8 @@ $body .= elgg_view('input/dropdown', array(
 	'name' => 'params[addortoaccess_glue]',
 	'value' => $vars['entity']->addortoaccess_glue,
 	'options_values' => array(
-		'yes' => elgg_echo('option:yes'),
-		'no' => elgg_echo('option:no')
+		'no' => elgg_echo('option:no'),
+		'yes' => elgg_echo('option:yes')
 	)
 ));
 $body .= elgg_view('output/longtext', array(

--- a/views/default/plugins/elgg_solr/settings.php
+++ b/views/default/plugins/elgg_solr/settings.php
@@ -153,6 +153,19 @@ $body .= elgg_view('output/longtext', array(
 	'class' => 'elgg-subtext'
 ));
 
+
+$body .= '<label>' . elgg_echo('elgg_solr:settings:addortoaccess') . '</label><br>';
+$body .= elgg_view('input/dropdown', array(
+	'name' => 'params[addortoaccess_glue]',
+	'value' => $vars['entity']->addortoaccess_glue,
+	'options_values' => array(
+		'yes' => elgg_echo('option:yes'),
+		'no' => elgg_echo('option:no')
+	)
+));
+$body .= '<br><br>';
+
+
 $body .= '<label>' . elgg_echo('elgg_solr:settings:highlight:prefix') . '</label>';
 $body .= elgg_view('input/text', array(
 	'name' => 'hl_prefix',

--- a/views/default/plugins/elgg_solr/settings.php
+++ b/views/default/plugins/elgg_solr/settings.php
@@ -163,7 +163,10 @@ $body .= elgg_view('input/dropdown', array(
 		'no' => elgg_echo('option:no')
 	)
 ));
-$body .= '<br><br>';
+$body .= elgg_view('output/longtext', array(
+	'value' => elgg_echo('elgg_solr:settings:addortoaccess:help'),
+	'class' => 'elgg-subtext'
+));
 
 
 $body .= '<label>' . elgg_echo('elgg_solr:settings:highlight:prefix') . '</label>';


### PR DESCRIPTION
When the scheme is set to by default use "AND", instead of "OR", the access_id list was also set to AND. This resulted in no results, because it's impossible to have an entity with multiple access id's.