### PR TITLE
Moved special objects to hooks

### DIFF
--- a/lib/hooks.php
+++ b/lib/hooks.php
@@ -1209,3 +1209,82 @@ function elgg_solr_comment_search($hook, $type, $return, $params) {
         'count' => $count,
     );
 }
+
+/**
+ * Manipulate the DocumentInterface for the user
+ *
+ * @param string $hook
+ * @param string $type
+ * @param \Solarium\QueryType\Update\Query\Document\DocumentInterface $return
+ * @param array $params
+ * @return \Solarium\QueryType\Update\Query\Document\DocumentInterface
+ */
+function elgg_solr_index_user($hook, $type, $return, $params) {
+	$entity = elgg_extract('entity', $params);
+
+	// Add username to doc
+	$return->username = $entity->username;
+
+	// Add profile fields to additional fields
+	$profile_fields = elgg_get_config('profile_fields');
+	if (is_array($profile_fields) && sizeof($profile_fields) > 0) {
+		foreach ($profile_fields as $shortname => $valtype) {
+			if (is_array($entity->$shortname)) {
+				$key = 'profile_' . $shortname . '_ss';
+			} else {
+				$key = 'profile_' . $shortname . '_s';
+			}
+
+			$return->$key = $entity->$shortname;
+		}
+	}
+
+	// Add group guids to the list
+	$groups = [];
+
+	foreach ($entity->getGroups() as $group) {
+		$groups[] = $group->getGUID();
+	}
+
+	$return->groups_is = $groups;
+
+	return $return;
+}
+
+/**
+ * Manipulate the DocumentInterface for the group
+ *
+ * @param string $hook
+ * @param string $type
+ * @param \Solarium\QueryType\Update\Query\Document\DocumentInterface $return
+ * @param array $params
+ * @return \Solarium\QueryType\Update\Query\Document\DocumentInterface
+ */
+function elgg_solr_index_group($hook, $type, $return, $params) {
+	$entity = elgg_extract('entity', $params);
+
+	// Add group fields to additional fields
+	$group_fields = elgg_get_config('group');
+	if (is_array($group_fields) && sizeof($group_fields) > 0) {
+		foreach ($group_fields as $shortname => $valtype) {
+			if (is_array($entity->$shortname)) {
+				$key = 'group_' . $shortname . '_ss';
+			} else {
+				$key = 'group_' . $shortname . '_s';
+			}
+
+			$return->$key = $entity->$shortname;
+		}
+	}
+
+	// Add all members to the doc
+	$members = [];
+
+	foreach ($entity->getMembers() as $member) {
+		$members[] = $member->getGUID();
+	}
+
+	$return->members_is = $members;
+
+	return $return;
+}

--- a/start.php
+++ b/start.php
@@ -54,9 +54,13 @@ function elgg_solr_init() {
 
 	// register functions for indexing
 	elgg_solr_register_solr_entity_type('object', 'file', 'elgg_solr_add_update_file');
-	elgg_solr_register_solr_entity_type('user', 'default', 'elgg_solr_add_update_user');
-	elgg_solr_register_solr_entity_type('object', 'default', 'elgg_solr_add_update_object_default');
-	elgg_solr_register_solr_entity_type('group', 'default', 'elgg_solr_add_update_group_default');
+	elgg_solr_register_solr_entity_type('user', 'default', 'elgg_solr_add_update');
+	elgg_solr_register_solr_entity_type('object', 'default', 'elgg_solr_add_update');
+	elgg_solr_register_solr_entity_type('group', 'default', 'elgg_solr_add_update');
+
+	// register hooks for indexing special objects
+	elgg_register_plugin_hook_handler('elgg_solr:index', 'user', 'elgg_solr_index_user');
+	elgg_register_plugin_hook_handler('elgg_solr:index', 'group', 'elgg_solr_index_group');
 
 	elgg_register_action('elgg_solr/reindex', __DIR__ . '/actions/reindex.php', 'admin');
 	elgg_register_action('elgg_solr/delete_index', __DIR__ . '/actions/delete_index.php', 'admin');


### PR DESCRIPTION
Now we don't need to have a separate code for user or groups. This helps to keep the code more clean. It's using the hook that's being fired after the first part of the Document is created.

Also added (sorry) the ability to push the custom profile and group fields to Solr. So custom plugins are able to easily search in this data. The scheme isn't changed.